### PR TITLE
Fixed Bash install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ iwr -useb https://raw.githubusercontent.com/NYRI4/Comfy-spicetify/main/install.p
 macOS and Linux -> **Bash**:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NYRI4/Comfy-spicetify/main/install.sh | sh
+wget https://raw.githubusercontent.com/NYRI4/Comfy-spicetify/main/install.sh; sh ./install.sh
 ```
 ### 📥 Manual Installation
 ---


### PR DESCRIPTION
The bash install method for Unix systems was not working, so I fixed it.